### PR TITLE
Fix ensureIndexed action

### DIFF
--- a/src/state/_common/actions.js
+++ b/src/state/_common/actions.js
@@ -425,7 +425,7 @@ function ensureIndexed(getSubstate, dataType, filter, order, start, length, acti
 		if (total != null){
 			const indexPage = commonSelectors.getIndexPage(getSubstate)(state, filter, order, start, length) ?? {};
 			const pages = _.chunk(Object.values(indexPage), PAGE_SIZE);
-			const promises = pages.map(page => {
+			const promises = pages.map((page, i) => {
 				const loadedKeys = page.filter(v => v != null);
 				if (loadedKeys.length === page.length) {
 					return; // page is already loaded
@@ -433,7 +433,7 @@ function ensureIndexed(getSubstate, dataType, filter, order, start, length, acti
 
 				const completeFilter = loadedKeys.length ? {...filter, key: {notin: loadedKeys}} : filter;
 
-				return dispatch(loadIndexedPage(dataType, completeFilter, order, start + i, changedOn, actionTypes, categoryPath))
+				return dispatch(loadIndexedPage(dataType, completeFilter, order, start + (i * PAGE_SIZE), changedOn, actionTypes, categoryPath))
 					.catch((err) => {
 						if (err.message === 'Index outdated'){
 							dispatch(refreshIndex(getSubstate, dataType, filter, order, actionTypes, categoryPath));


### PR DESCRIPTION
Somewhere in the old code is a bug. Request to server is firing on each dispatch in case of vodních živočichů (https://github.com/gisat/app-tacrGeoinvaze/blob/c887f25df05e5a1f6f82f1b2ec753955ca33db29/src/components/Header/components/CaseList/index.js#L36).

I had a problem reading the loops with `i`s `j`s, adding, comparing, ... so I rewrote it a bit and now request is sent only first time.