### PR TITLE
Add merging pickable and hoverable values from state and map.

### DIFF
--- a/src/state/Maps/selectors.js
+++ b/src/state/Maps/selectors.js
@@ -751,6 +751,28 @@ const getAttributeRelationsFilterFromLayerState = createRecomputeSelector(
 	recomputeSelectorOptions
 );
 
+const getMergedBoolLayerOptionValue = (
+	layerStateOptions,
+	configuration,
+	value
+) => {
+	const defaultValue = false;
+	const layerStateValueValid =
+		layerStateOptions &&
+		Object.hasOwn(layerStateOptions, value) &&
+		(layerStateOptions[value] === true || layerStateOptions[value] === false);
+	const configurationValueValid =
+		configuration &&
+		Object.hasOwn(configuration, value) &&
+		(configuration[value] === true || configuration[value] === false);
+
+	return layerStateValueValid
+		? layerStateOptions[value]
+		: configurationValueValid
+		? configuration[value]
+		: defaultValue;
+};
+
 /**
  * @param spatialDataSource {Object}
  * @param layerState {Object} layer definition from state or passed to the Map component
@@ -815,11 +837,20 @@ const getFinalLayerByDataSourceAndLayerState = createRecomputeSelector(
 				configuration && Object.hasOwn(configuration, 'singleTile')
 					? configuration.singleTile
 					: false;
+			const hoverable = getMergedBoolLayerOptionValue(
+				layerStateOptions,
+				configuration,
+				'hoverable'
+			);
 			// TODO pickable is hoverable now, split to selectable/hoverable once it is implemented in ptr-maps
 			const pickable =
-				configuration && Object.hasOwn(configuration, 'pickable')
-					? configuration.pickable && layerStateOptions?.hoverable
-					: false;
+				hoverable &&
+				getMergedBoolLayerOptionValue(
+					layerStateOptions,
+					configuration,
+					'pickable'
+				);
+
 			const fetchedTile =
 				configuration && Object.hasOwn(configuration, 'fetchedTile')
 					? configuration.fetchedTile
@@ -845,6 +876,7 @@ const getFinalLayerByDataSourceAndLayerState = createRecomputeSelector(
 				},
 				singleTile,
 				pickable,
+				hoverable,
 				fetchedTile,
 				url,
 			};
@@ -993,7 +1025,6 @@ const getMapLayers = createRecomputeSelector((mapKey, layersState) => {
 	if (!layersState) {
 		layersState = getLayersStateByMapKeyObserver(mapKey);
 	}
-
 	if (layersState) {
 		let finalLayers = [];
 

--- a/tests/state/Maps/selectors/getFinalLayerByDataSourceAndLayerState-test.js
+++ b/tests/state/Maps/selectors/getFinalLayerByDataSourceAndLayerState-test.js
@@ -184,6 +184,7 @@ describe('getFinalLayerByDataSourceAndLayerState', function () {
 			options: {
 				url: 'https://wm.s',
 				singleTile: false,
+				hoverable: false,
 				fetchedTile: false,
 				pickable: false,
 				params: {
@@ -231,6 +232,7 @@ describe('getFinalLayerByDataSourceAndLayerState', function () {
 			options: {
 				url: 'http://localhost:3000/wms.png',
 				singleTile: false,
+				hoverable: false,
 				fetchedTile: false,
 				pickable: false,
 				params: {
@@ -280,6 +282,7 @@ describe('getFinalLayerByDataSourceAndLayerState', function () {
 			type: 'wms',
 			options: {
 				url: 'https://wm.s',
+				hoverable: false,
 				fetchedTile: false,
 				singleTile: true,
 				pickable: false,
@@ -329,6 +332,7 @@ describe('getFinalLayerByDataSourceAndLayerState', function () {
 			options: {
 				url: 'https://wm.s',
 				fetchedTile: true,
+				hoverable: false,
 				singleTile: false,
 				pickable: false,
 				params: {
@@ -380,6 +384,7 @@ describe('getFinalLayerByDataSourceAndLayerState', function () {
 			options: {
 				url: 'https://wm.s',
 				fetchedTile: false,
+				hoverable: true,
 				singleTile: false,
 				pickable: true,
 				params: {


### PR DESCRIPTION
Both values pickable and hoverable must be merged from datasource and map state. 

If map state value is defined, then it override datasource value.