### PR TITLE
Maps actions: remove map layers by layerTemplateKey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"fast-stringify": "^2.0.0",
 				"isomorphic-fetch": "^3.0.0",
 				"lodash": "^4.17.21",
-				"moment": "^2.29.1",
+				"moment": "^2.29.4",
 				"query-string": "^6.14.0",
 				"re-reselect": "^4.0.0",
 				"react-redux": "^8.0.2",
@@ -27,8 +27,8 @@
 				"reselect": "^4.1.2"
 			},
 			"devDependencies": {
-				"@babel/cli": "^7.16.0",
-				"@babel/core": "^7.16.0",
+				"@babel/cli": "^7.23.0",
+				"@babel/core": "^7.23.2",
 				"@babel/plugin-transform-runtime": "^7.16.0",
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-react": "^7.16.0",
@@ -48,7 +48,7 @@
 				"flat": "^5.0.2",
 				"glob": "^7.2.0",
 				"husky": "^7.0.4",
-				"mocha": "^10.0.0",
+				"mocha": "^10.2.0",
 				"npm-run-all": "^4.1.5",
 				"nyc": "^15.1.0",
 				"path": "^0.12.7",
@@ -80,16 +80,16 @@
 			}
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.10.tgz",
-			"integrity": "sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.0.tgz",
+			"integrity": "sha512-17E1oSkGk2IwNILM4jtfAvgjt+ohmpfBky8aLerUfYZhiPNg7ca+CRCxZn8QDxwNhV/upsc2VHBCqGFIR+iBfA==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.8",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"commander": "^4.0.1",
-				"convert-source-map": "^1.1.0",
+				"convert-source-map": "^2.0.0",
 				"fs-readdir-recursive": "^1.1.0",
-				"glob": "^7.0.0",
+				"glob": "^7.2.0",
 				"make-dir": "^2.1.0",
 				"slash": "^2.0.0"
 			},
@@ -108,6 +108,12 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/cli/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
 		"node_modules/@babel/cli/node_modules/slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -118,47 +124,48 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.16.7"
+				"@babel/highlight": "^7.22.13",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-			"integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+			"integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-			"integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
 			"dev": true,
 			"dependencies": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.18.2",
-				"@babel/helper-compilation-targets": "^7.18.2",
-				"@babel/helper-module-transforms": "^7.18.0",
-				"@babel/helpers": "^7.18.2",
-				"@babel/parser": "^7.18.0",
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.2",
-				"@babel/types": "^7.18.2",
-				"convert-source-map": "^1.7.0",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helpers": "^7.23.2",
+				"@babel/parser": "^7.23.0",
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -168,14 +175,21 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
+		"node_modules/@babel/core/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
 		"node_modules/@babel/generator": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-			"integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.2",
-				"@jridgewell/gen-mapping": "^0.3.0",
+				"@babel/types": "^7.23.0",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			},
 			"engines": {
@@ -183,12 +197,12 @@
 			}
 		},
 		"node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-			"integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
 				"@jridgewell/trace-mapping": "^0.3.9"
 			},
@@ -222,22 +236,35 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
-			"integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.17.10",
-				"@babel/helper-validator-option": "^7.16.7",
-				"browserslist": "^4.20.2",
-				"semver": "^6.3.0"
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-validator-option": "^7.22.15",
+				"browserslist": "^4.21.9",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
 			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
 			"version": "7.18.0",
@@ -296,9 +323,9 @@
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-			"integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -317,25 +344,25 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.17.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -354,34 +381,34 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
-			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/helper-simple-access": "^7.17.7",
-				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.0",
-				"@babel/types": "^7.18.0"
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
@@ -436,12 +463,12 @@
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
-			"integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.2"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -460,30 +487,39 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -505,27 +541,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
-			"integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.2",
-				"@babel/types": "^7.18.2"
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -533,9 +569,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-			"integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1780,33 +1816,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.16.7",
-				"@babel/parser": "^7.16.7",
-				"@babel/types": "^7.16.7"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-			"integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.18.2",
-				"@babel/helper-environment-visitor": "^7.18.2",
-				"@babel/helper-function-name": "^7.17.9",
-				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.18.0",
-				"@babel/types": "^7.18.2",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1815,12 +1851,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.18.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-			"integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -2016,9 +2053,9 @@
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -2058,19 +2095,19 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-			"integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@jvitela/recompute": {
@@ -2404,12 +2441,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
 			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
-		},
-		"node_modules/@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.1",
@@ -3224,9 +3255,9 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.20.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -3236,14 +3267,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001332",
-				"electron-to-chromium": "^1.4.118",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.3",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001541",
+				"electron-to-chromium": "^1.4.535",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3370,9 +3404,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001346",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-			"integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+			"version": "1.0.30001553",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+			"integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
 			"dev": true,
 			"funding": [
 				{
@@ -3382,6 +3416,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -3861,9 +3899,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.146",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.146.tgz",
-			"integrity": "sha512-4eWebzDLd+hYLm4csbyMU2EbBnqhwl8Oe9eF/7CBDPWcRxFmqzx4izxvHH+lofQxzieg8UbB8ZuzNTxeukzfTg==",
+			"version": "1.4.566",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.566.tgz",
+			"integrity": "sha512-mv+fAy27uOmTVlUULy15U3DVJ+jg+8iyKH1bpwboCRhtDC69GKf1PPTZvEIhCyDr81RFqfxZJYrbgp933a1vtg==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -5933,9 +5971,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -6441,12 +6479,11 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-			"integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
 			"dev": true,
 			"dependencies": {
-				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.3",
@@ -6656,9 +6693,9 @@
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.3",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
 			"engines": {
 				"node": "*"
 			}
@@ -6805,9 +6842,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-			"integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
 		"node_modules/nopt": {
@@ -8513,9 +8550,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -9258,6 +9295,36 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9735,22 +9802,28 @@
 			}
 		},
 		"@babel/cli": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.10.tgz",
-			"integrity": "sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.0.tgz",
+			"integrity": "sha512-17E1oSkGk2IwNILM4jtfAvgjt+ohmpfBky8aLerUfYZhiPNg7ca+CRCxZn8QDxwNhV/upsc2VHBCqGFIR+iBfA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.8",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
 				"chokidar": "^3.4.0",
 				"commander": "^4.0.1",
-				"convert-source-map": "^1.1.0",
+				"convert-source-map": "^2.0.0",
 				"fs-readdir-recursive": "^1.1.0",
-				"glob": "^7.0.0",
+				"glob": "^7.2.0",
 				"make-dir": "^2.1.0",
 				"slash": "^2.0.0"
 			},
 			"dependencies": {
+				"convert-source-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+					"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+					"dev": true
+				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -9760,61 +9833,71 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.16.7"
+				"@babel/highlight": "^7.22.13",
+				"chalk": "^2.4.2"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.17.10",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-			"integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+			"integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-			"integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
 			"dev": true,
 			"requires": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.18.2",
-				"@babel/helper-compilation-targets": "^7.18.2",
-				"@babel/helper-module-transforms": "^7.18.0",
-				"@babel/helpers": "^7.18.2",
-				"@babel/parser": "^7.18.0",
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.2",
-				"@babel/types": "^7.18.2",
-				"convert-source-map": "^1.7.0",
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-module-transforms": "^7.23.0",
+				"@babel/helpers": "^7.23.2",
+				"@babel/parser": "^7.23.0",
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"dependencies": {
+				"convert-source-map": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+					"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-			"integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.2",
-				"@jridgewell/gen-mapping": "^0.3.0",
+				"@babel/types": "^7.23.0",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
 			},
 			"dependencies": {
 				"@jridgewell/gen-mapping": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-					"integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+					"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 					"dev": true,
 					"requires": {
-						"@jridgewell/set-array": "^1.0.0",
+						"@jridgewell/set-array": "^1.0.1",
 						"@jridgewell/sourcemap-codec": "^1.4.10",
 						"@jridgewell/trace-mapping": "^0.3.9"
 					}
@@ -9841,15 +9924,33 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
-			"integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.17.10",
-				"@babel/helper-validator-option": "^7.16.7",
-				"browserslist": "^4.20.2",
-				"semver": "^6.3.0"
+				"@babel/compat-data": "^7.22.9",
+				"@babel/helper-validator-option": "^7.22.15",
+				"browserslist": "^4.21.9",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
@@ -9894,9 +9995,9 @@
 			}
 		},
 		"@babel/helper-environment-visitor": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-			"integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -9909,22 +10010,22 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.16.7",
-				"@babel/types": "^7.17.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -9937,28 +10038,25 @@
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.15"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
-			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.16.7",
-				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/helper-simple-access": "^7.17.7",
-				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.0",
-				"@babel/types": "^7.18.0"
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -10001,12 +10099,12 @@
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
-			"integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.2"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
@@ -10019,24 +10117,30 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.22.5"
 			}
 		},
+		"@babel/helper-string-parser": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"dev": true
+		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
@@ -10052,31 +10156,31 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
-			"integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.18.2",
-				"@babel/types": "^7.18.2"
+				"@babel/template": "^7.22.15",
+				"@babel/traverse": "^7.23.2",
+				"@babel/types": "^7.23.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.16.7",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-			"integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -10904,41 +11008,42 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.16.7",
-				"@babel/parser": "^7.16.7",
-				"@babel/types": "^7.16.7"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-			"integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.18.2",
-				"@babel/helper-environment-visitor": "^7.18.2",
-				"@babel/helper-function-name": "^7.17.9",
-				"@babel/helper-hoist-variables": "^7.16.7",
-				"@babel/helper-split-export-declaration": "^7.16.7",
-				"@babel/parser": "^7.18.0",
-				"@babel/types": "^7.18.2",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.18.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-			"integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -11093,9 +11198,9 @@
 			}
 		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true
 		},
 		"@jridgewell/set-array": {
@@ -11128,19 +11233,19 @@
 			}
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-			"integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+			"version": "0.3.20",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"@jvitela/recompute": {
@@ -11417,12 +11522,6 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
 			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
-		},
-		"@ungap/promise-all-settled": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-			"dev": true
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",
@@ -12086,16 +12185,15 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.20.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001332",
-				"electron-to-chromium": "^1.4.118",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.3",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001541",
+				"electron-to-chromium": "^1.4.535",
+				"node-releases": "^2.0.13",
+				"update-browserslist-db": "^1.0.13"
 			}
 		},
 		"buffer-from": {
@@ -12193,9 +12291,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001346",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-			"integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+			"version": "1.0.30001553",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz",
+			"integrity": "sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==",
 			"dev": true
 		},
 		"caseless": {
@@ -12562,9 +12660,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.146",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.146.tgz",
-			"integrity": "sha512-4eWebzDLd+hYLm4csbyMU2EbBnqhwl8Oe9eF/7CBDPWcRxFmqzx4izxvHH+lofQxzieg8UbB8ZuzNTxeukzfTg==",
+			"version": "1.4.566",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.566.tgz",
+			"integrity": "sha512-mv+fAy27uOmTVlUULy15U3DVJ+jg+8iyKH1bpwboCRhtDC69GKf1PPTZvEIhCyDr81RFqfxZJYrbgp933a1vtg==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -14115,9 +14213,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jsonparse": {
@@ -14504,12 +14602,11 @@
 			"dev": true
 		},
 		"mocha": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-			"integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
 			"dev": true,
 			"requires": {
-				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
 				"chokidar": "3.5.3",
@@ -14660,9 +14757,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.29.3",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-			"integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 		},
 		"mri": {
 			"version": "1.2.0",
@@ -14767,9 +14864,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-			"integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
 			"dev": true
 		},
 		"nopt": {
@@ -16066,9 +16163,9 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
 		},
 		"serialize-javascript": {
@@ -16632,6 +16729,16 @@
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
+			}
+		},
+		"update-browserslist-db": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"dev": true,
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"fast-stringify": "^2.0.0",
 		"isomorphic-fetch": "^3.0.0",
 		"lodash": "^4.17.21",
-		"moment": "^2.29.1",
+		"moment": "^2.29.4",
 		"query-string": "^6.14.0",
 		"re-reselect": "^4.0.0",
 		"react-redux": "^8.0.2",
@@ -48,8 +48,8 @@
 		"reselect": "^4.1.2"
 	},
 	"devDependencies": {
-		"@babel/cli": "^7.16.0",
-		"@babel/core": "^7.16.0",
+		"@babel/cli": "^7.23.0",
+		"@babel/core": "^7.23.2",
 		"@babel/plugin-transform-runtime": "^7.16.0",
 		"@babel/preset-env": "^7.16.0",
 		"@babel/preset-react": "^7.16.0",
@@ -69,7 +69,7 @@
 		"flat": "^5.0.2",
 		"glob": "^7.2.0",
 		"husky": "^7.0.4",
-		"mocha": "^10.0.0",
+		"mocha": "^10.2.0",
 		"npm-run-all": "^4.1.5",
 		"nyc": "^15.1.0",
 		"path": "^0.12.7",

--- a/src/state/Maps/actions.js
+++ b/src/state/Maps/actions.js
@@ -219,6 +219,24 @@ const removeMapLayer = (mapKey, layerKey) => {
 	};
 };
 
+// TODO test
+const removeMapLayersByLayerTemplateKey = (mapKey, layerTemplateKey) => {
+	return (dispatch, getState) => {
+		const state = getState();
+		const layersState = Select.maps.getLayersStateByMapKey(
+			state,
+			mapKey,
+		);
+		if (layersState?.length) {
+			layersState.forEach(layer => {
+				if (layer.layerTemplateKey === layerTemplateKey) {
+					dispatch(actionRemoveMapLayer(mapKey, layer.key));
+				}
+			});
+		}
+	};
+}
+
 /**
  * Remove all layers satisfying filter from map
  * @param mapKey {string}
@@ -1168,6 +1186,7 @@ export default {
 	removeMap,
 	removeMapFromSet,
 	removeMapLayer,
+	removeMapLayersByLayerTemplateKey,
 	removeMapLayers,
 	removeMapLayersByFilter,
 	removeAllMapLayers: actionRemoveAllMapLayers,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.0.0-dev.7`

<details>
  <summary>Changelog</summary>

  #### 🐾 Patch
  
  - Maps actions: remove map layers by layerTemplateKey [#155](https://github.com/gisat-panther/ptr-state/pull/155) ([@vlach1989](https://github.com/vlach1989))
  
  #### ⚠️ Pushed to `dev`
  
  - Add MVT layer type ([@vdubr](https://github.com/vdubr))
  - Merge vector datasource wwith fid datasource in selectors ([@vdubr](https://github.com/vdubr))
  - Rename cog to cogBitmap ([@vdubr](https://github.com/vdubr))
  - Temporary fix common getNodeByType ([@vdubr](https://github.com/vdubr))
  - Implement vectorKey instead of tablName and schema in data request ([@vdubr](https://github.com/vdubr))
  - Modify /vector filter like in last version of BE ([@vdubr](https://github.com/vdubr))
  - Ensure spatial data source. Missing vector relations ([@vdubr](https://github.com/vdubr))
  - Adopt new metadata BE ([@vdubr](https://github.com/vdubr))
  - 3.0.0-dev.0 ([@vdubr](https://github.com/vdubr))
  
  #### Authors: 2
  
  - Pavel Vlach ([@vlach1989](https://github.com/vlach1989))
  - Vojtěch Dubrovský ([@vdubr](https://github.com/vdubr))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
