### PR TITLE
Selections: distinct items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.0.0-dev.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@gisatcz/ptr-core": "^1.7.0",
+				"@gisatcz/ptr-core": "^1.8.0",
 				"@gisatcz/ptr-tile-grid": "^0.2.0",
 				"@gisatcz/ptr-utils": "^1.6.0",
 				"@jvitela/recompute": "^0.3.4",
@@ -1950,9 +1950,9 @@
 			"dev": true
 		},
 		"node_modules/@gisatcz/ptr-core": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@gisatcz/ptr-core/-/ptr-core-1.7.0.tgz",
-			"integrity": "sha512-9GsYKyczuukUJ/B2xUiSTqFVQoBFc9SqdTifEzz1nvaAuc+L8BoAN5RLwO4Qyqa2E56sfaiRBu7JZdGi91CwfQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@gisatcz/ptr-core/-/ptr-core-1.8.0.tgz",
+			"integrity": "sha512-0JSHbD0QzswRYGX0GPIXC4+E6G+ssn3weSZlC6apghVodZUT8+HhP1eGqhKB3SJ/pGUMfLGC2/e87eDBsbSXFg==",
 			"dependencies": {
 				"@gisatcz/cross-package-react-context": "^0.2.0",
 				"classnames": "^2.3.1",
@@ -11115,9 +11115,9 @@
 			"dev": true
 		},
 		"@gisatcz/ptr-core": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@gisatcz/ptr-core/-/ptr-core-1.7.0.tgz",
-			"integrity": "sha512-9GsYKyczuukUJ/B2xUiSTqFVQoBFc9SqdTifEzz1nvaAuc+L8BoAN5RLwO4Qyqa2E56sfaiRBu7JZdGi91CwfQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@gisatcz/ptr-core/-/ptr-core-1.8.0.tgz",
+			"integrity": "sha512-0JSHbD0QzswRYGX0GPIXC4+E6G+ssn3weSZlC6apghVodZUT8+HhP1eGqhKB3SJ/pGUMfLGC2/e87eDBsbSXFg==",
 			"requires": {
 				"@gisatcz/cross-package-react-context": "^0.2.0",
 				"classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"react-dom": "^16.13.1 || ^17.0.2 || ^18.1.0 "
 	},
 	"dependencies": {
-		"@gisatcz/ptr-core": "^1.7.0",
+		"@gisatcz/ptr-core": "^1.8.0",
 		"@gisatcz/ptr-tile-grid": "^0.2.0",
 		"@gisatcz/ptr-utils": "^1.6.0",
 		"@jvitela/recompute": "^0.3.4",

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -621,6 +621,7 @@ export default utils.deepKeyMirror({
 		SET: {
 			FEATURE_KEYS_FILTER: {
 				KEYS: null,
+				SET: null,
 			},
 		},
 		CLEAR: {

--- a/src/state/Selections/actions.js
+++ b/src/state/Selections/actions.js
@@ -1,6 +1,7 @@
 import common from '../_common/actions';
 import ActionTypes from '../../constants/ActionTypes';
 import Select from '../Select';
+import helpers from './helpers';
 
 const add = common.add(ActionTypes.SELECTIONS);
 const setActiveKey = common.setActiveKey(ActionTypes.SELECTIONS);
@@ -13,6 +14,29 @@ const setActiveSelectionFeatureKeysFilterKeys = selectionKeys => {
 		let activeSelectionKey = Select.selections.getActiveKey(getState());
 		if (activeSelectionKey && selectionKeys) {
 			dispatch(setFeatureKeysFilterKeys(activeSelectionKey, selectionKeys));
+		}
+	};
+};
+
+/**
+ * @param selectionKey {string} Id of selection, usually uuid
+ * @param featureKeys {Array} list of features
+ */
+const setFeatureKeysFilterKeys = (selectionKey, featureKeys) => {
+	return (dispatch, getState) => {
+		const selection = Select.selections.getByKey(getState(), selectionKey);
+		if (selection) {
+			const distinctItems = selection?.data?.distinctItems;
+			if (distinctItems) {
+				const featureKeysFilter =
+					helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+						selection.data.featureKeysFilter,
+						featureKeys
+					);
+				dispatch(actionSetFeatureKeysFilter(selectionKey, featureKeysFilter));
+			} else {
+				dispatch(actionSetFeatureKeysFilterKeys(selectionKey, featureKeys));
+			}
 		}
 	};
 };
@@ -34,11 +58,19 @@ function clearFeatureKeysFilter(key) {
 	};
 }
 
-function setFeatureKeysFilterKeys(key, featureKeys) {
+function actionSetFeatureKeysFilterKeys(key, featureKeys) {
 	return {
 		type: ActionTypes.SELECTIONS.SET.FEATURE_KEYS_FILTER.KEYS,
 		key,
 		featureKeys,
+	};
+}
+
+function actionSetFeatureKeysFilter(key, featureKeysFilter) {
+	return {
+		type: ActionTypes.SELECTIONS.SET.FEATURE_KEYS_FILTER.SET,
+		key,
+		featureKeysFilter,
 	};
 }
 

--- a/src/state/Selections/helpers.js
+++ b/src/state/Selections/helpers.js
@@ -1,0 +1,85 @@
+import {isEmpty as _isEmpty, forIn as _forIn} from 'lodash';
+
+/**
+ * Helper for feature keys - colours pairing
+ * @param featureKeysFilter {Object}
+ * @param featureKeysFilter.keys {Array} Previous feature keys
+ * @param [featureKeysFilter.keyColourIndexPairs] {Object} Object, where key is feature key and value is index in colourPalette
+ * @param newKeys {Array} List of new feature keys
+ */
+function getUpdatedFeatureKeysFilterForDistinctItems(
+	featureKeysFilter,
+	newKeys = []
+) {
+	if (featureKeysFilter) {
+		const {keys: oldKeys, keyColourIndexPairs} = featureKeysFilter;
+
+		// compare oldKeys and newKeys -> array of keys removed, array of keys added
+		const {added, removed} = compareArrays(oldKeys, newKeys);
+
+		const updatedPairs = {};
+
+		// Go through keyColourIndexPairs and preserve all features which were not removed
+		if (!_isEmpty(keyColourIndexPairs)) {
+			_forIn(keyColourIndexPairs, (indexInPalette, featureKey) => {
+				// not strict equal, because object keys are still represented as string, even if feature keys are numbers
+				if (!removed.find(item => item == featureKey)) {
+					updatedPairs[featureKey] = indexInPalette;
+				}
+			});
+		}
+
+		if (added.length) {
+			// Sorting in ascending order
+			let sortedColourIndexes = Object.values(updatedPairs)?.sort(
+				(a, b) => a - b
+			);
+
+			let i = 0;
+			// if index is missing, add the key for index since there is empty newKeys array
+			while (added.length) {
+				if (sortedColourIndexes[i] !== i) {
+					const featureKeyToAdd = added.shift();
+					updatedPairs[featureKeyToAdd] = i;
+					sortedColourIndexes.splice(i, 0, i);
+				}
+				i++;
+			}
+		}
+
+		return {
+			keyColourIndexPairs: !_isEmpty(updatedPairs) ? updatedPairs : null,
+			keys: newKeys,
+		};
+	} else {
+		return new Error(
+			'getUpdatedFeatureKeysFilterForDistinctItems: No featureKeysFilter given!'
+		);
+	}
+}
+
+/**
+ * Compare two arrays and return an object with added and removed items.
+ *
+ * @param {Array} arr1 - The first array to compare.
+ * @param {Array} arr2 - The second array to compare.
+ * @returns {Object} An object with 'added' and 'removed' properties.
+ */
+function compareArrays(arr1, arr2) {
+	// Find items in arr2 that are not present in arr1 (added items).
+	const added = arr2.filter(item => !arr1.includes(item));
+
+	// Find items in arr1 that are not present in arr2 (removed items).
+	const removed = arr1.filter(item => !arr2.includes(item));
+
+	// Return an object with added and removed items.
+	return {
+		added,
+		removed,
+	};
+}
+
+export default {
+	compareArrays,
+	getUpdatedFeatureKeysFilterForDistinctItems,
+};

--- a/src/state/Selections/reducers.js
+++ b/src/state/Selections/reducers.js
@@ -20,6 +20,22 @@ const clearFeatureKeysFilter = (state, key) => {
 	return {...state, byKey: updatedByKey};
 };
 
+const setFeatureKeysFilter = (state, key, featureKeysFilter) => {
+	return {
+		...state,
+		byKey: {
+			...state.byKey,
+			[key]: {
+				...state.byKey[key],
+				data: {
+					...state.byKey[key].data,
+					featureKeysFilter,
+				},
+			},
+		},
+	};
+};
+
 const setFeatureKeysFilterKeys = (state, key, featureKeys) => {
 	let updatedByKey = {
 		...state.byKey,
@@ -46,6 +62,8 @@ export default (state = INITIAL_STATE, action) => {
 			return clearFeatureKeysFilter(state, action.key);
 		case ActionTypes.SELECTIONS.SET_ACTIVE_KEY:
 			return common.setActive(state, action);
+		case ActionTypes.SELECTIONS.SET.FEATURE_KEYS_FILTER.SET:
+			return setFeatureKeysFilter(state, action.key, action.featureKeysFilter);
 		case ActionTypes.SELECTIONS.SET.FEATURE_KEYS_FILTER.KEYS:
 			return setFeatureKeysFilterKeys(state, action.key, action.featureKeys);
 		default:

--- a/src/state/Selections/selectors.js
+++ b/src/state/Selections/selectors.js
@@ -12,6 +12,7 @@ const getActive = common.getActive(getSubstate);
 const getActiveKey = common.getActiveKey(getSubstate);
 const getAllAsObject = common.getAllAsObject(getSubstate);
 const getAll = common.getAll(getSubstate);
+const getByKey = common.getByKey(getSubstate);
 
 const getAllAsObjectWithStyles = createSelector(
 	[getAllAsObject, StyleSelectors.getAllAsObject],
@@ -101,6 +102,8 @@ export default {
 	getAllAsObject,
 
 	getAllAsObjectWithStyles,
+
+	getByKey,
 
 	prepareSelectionByLayerStateSelected,
 };

--- a/tests/state/Selections/helpers/compareArrays.js
+++ b/tests/state/Selections/helpers/compareArrays.js
@@ -1,0 +1,40 @@
+import {assert} from 'chai';
+import helpers from '../../../../src/state/Selections/helpers';
+
+// Test case 1: Arrays have common elements.
+describe('Compare Arrays', () => {
+	it('should return added and removed elements', () => {
+		const array1 = [1, 2, 3, 4, 5];
+		const array2 = [3, 4, 5, 6, 7];
+		const result = helpers.compareArrays(array1, array2);
+
+		assert.deepStrictEqual(result, {
+			added: [6, 7],
+			removed: [1, 2],
+		});
+	});
+
+	// Test case 2: Arrays are completely different.
+	it('should return all elements as added and removed', () => {
+		const array1 = [1, 2, 3];
+		const array2 = [4, 5, 6];
+		const result = helpers.compareArrays(array1, array2);
+
+		assert.deepStrictEqual(result, {
+			added: [4, 5, 6],
+			removed: [1, 2, 3],
+		});
+	});
+
+	// Test case 3: Arrays are identical.
+	it('should return empty added and removed arrays', () => {
+		const array1 = [1, 2, 3];
+		const array2 = [1, 2, 3];
+		const result = helpers.compareArrays(array1, array2);
+
+		assert.deepStrictEqual(result, {
+			added: [],
+			removed: [],
+		});
+	});
+});

--- a/tests/state/Selections/helpers/getUpdatedFeatureKeysFilterForDistinctItems.js
+++ b/tests/state/Selections/helpers/getUpdatedFeatureKeysFilterForDistinctItems.js
@@ -1,0 +1,240 @@
+import {assert} from 'chai';
+import helpers from '../../../../src/state/Selections/helpers';
+
+describe('getUpdatedFeatureKeysFilterForDistinctItems', function () {
+	const featureKeysFilter = {
+		keys: [],
+	};
+
+	it('should add one item', () => {
+		const newKeys = ['a'];
+		const expectedResult = {
+			keys: ['a'],
+			keyColourIndexPairs: {
+				a: 0,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should add one two items', () => {
+		const newKeys = ['a', 'b'];
+		const expectedResult = {
+			keys: ['a', 'b'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should remove one item', () => {
+		const featureKeysFilter2 = {
+			keys: ['a', 'b'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+			},
+		};
+
+		const newKeys = ['b'];
+		const expectedResult = {
+			keys: ['b'],
+			keyColourIndexPairs: {
+				b: 1,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter2,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should remove two items', () => {
+		const featureKeysFilter3 = {
+			keys: ['a', 'b'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+			},
+		};
+
+		const newKeys = [];
+		const expectedResult = {
+			keys: [],
+			keyColourIndexPairs: null,
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter3,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should add items to empty spaces', () => {
+		const featureKeysFilter4 = {
+			keys: ['a', 'b', 'd', 'f'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+				d: 3,
+				f: 5,
+			},
+		};
+
+		const newKeys = ['a', 'b', 'd', 'f', 'c', 'e'];
+		const expectedResult = {
+			keys: ['a', 'b', 'd', 'f', 'c', 'e'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+				d: 3,
+				f: 5,
+				c: 2,
+				e: 4,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter4,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should replace items', () => {
+		const featureKeysFilter5 = {
+			keys: ['a', 'b', 'd', 'f'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+				d: 3,
+				f: 5,
+			},
+		};
+
+		const newKeys = ['x'];
+		const expectedResult = {
+			keys: ['x'],
+			keyColourIndexPairs: {
+				x: 0,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter5,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should add one item to existing', () => {
+		const featureKeysFilter6 = {
+			keys: ['a', 'b'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+			},
+		};
+
+		const newKeys = ['a', 'b', 'c'];
+		const expectedResult = {
+			keys: ['a', 'b', 'c'],
+			keyColourIndexPairs: {
+				a: 0,
+				b: 1,
+				c: 2,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter6,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should remove one item from existing', () => {
+		const featureKeysFilter7 = {
+			keys: ['a', 'b', 'c'],
+			keyColourIndexPairs: {
+				c: 2,
+				a: 0,
+				b: 1,
+			},
+		};
+
+		const newKeys = ['b', 'c'];
+		const expectedResult = {
+			keys: ['b', 'c'],
+			keyColourIndexPairs: {
+				b: 1,
+				c: 2,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter7,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+
+	it('should handle even with numbers', () => {
+		const featureKeysFilter7 = {
+			keys: [75, 40, 50],
+			keyColourIndexPairs: {
+				75: 2,
+				40: 0,
+				50: 1,
+			},
+		};
+
+		const newKeys = [40, 50];
+		const expectedResult = {
+			keys: [40, 50],
+			keyColourIndexPairs: {
+				40: 0,
+				50: 1,
+			},
+		};
+
+		assert.deepEqual(
+			helpers.getUpdatedFeatureKeysFilterForDistinctItems(
+				featureKeysFilter7,
+				newKeys
+			),
+			expectedResult
+		);
+	});
+});


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.0.0-dev.12`

<details>
  <summary>Changelog</summary>

  #### 🐾 Patch
  
  - Selections: distinct items [#157](https://github.com/gisat-panther/ptr-state/pull/157) ([@vlach1989](https://github.com/vlach1989))
  - Temporary comment tests [#158](https://github.com/gisat-panther/ptr-state/pull/158) ([@vdubr](https://github.com/vdubr))
  - Add selection to MVT layer [#156](https://github.com/gisat-panther/ptr-state/pull/156) ([@vdubr](https://github.com/vdubr))
  - Maps actions: remove map layers by layerTemplateKey [#155](https://github.com/gisat-panther/ptr-state/pull/155) ([@vlach1989](https://github.com/vlach1989))
  
  #### ⚠️ Pushed to `dev`
  
  - Fix selection to MVT layer ([@vdubr](https://github.com/vdubr))
  - Merge commit '68dae8e6086e869d3d83ee6f0f5f800ed80f93a4' into dev ([@vdubr](https://github.com/vdubr))
  - Expose new actions from attributeSets ([@vdubr](https://github.com/vdubr))
  - Add MVT layer type ([@vdubr](https://github.com/vdubr))
  - Merge vector datasource wwith fid datasource in selectors ([@vdubr](https://github.com/vdubr))
  - Rename cog to cogBitmap ([@vdubr](https://github.com/vdubr))
  - Temporary fix common getNodeByType ([@vdubr](https://github.com/vdubr))
  - Implement vectorKey instead of tablName and schema in data request ([@vdubr](https://github.com/vdubr))
  - Modify /vector filter like in last version of BE ([@vdubr](https://github.com/vdubr))
  - Ensure spatial data source. Missing vector relations ([@vdubr](https://github.com/vdubr))
  - Adopt new metadata BE ([@vdubr](https://github.com/vdubr))
  - 3.0.0-dev.0 ([@vdubr](https://github.com/vdubr))
  
  #### Authors: 2
  
  - Pavel Vlach ([@vlach1989](https://github.com/vlach1989))
  - Vojtěch Dubrovský ([@vdubr](https://github.com/vdubr))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
