### PR TITLE
chore: add release config for dev branch pre-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,15 @@
 		"rollup-plugin-filesize": "^9.1.0",
 		"slash": "3.0.0"
 	},
+	"release": {
+		"branches": [
+			"master",
+			{
+				"name": "dev",
+				"prerelease": true
+			}
+		]
+	},
 	"scripts": {
 		"clean": "rimraf dist",
 		"start": "cross-env BABEL_ENV=development run-s clean && run-p start:es start:cjs start:lib:es",


### PR DESCRIPTION
## Summary
Add release configuration to enable semantic-release to publish pre-release versions on dev branch pushes.

## Changes
- Add `"release"` configuration to `package.json` with:
  - `master` branch for stable releases
  - `dev` branch as pre-release channel

This enables pre-release builds (e.g., `3.0.0-dev.1`) to be automatically published when code is pushed to the `dev` branch.