### PR TITLE
fix: update repository URL to match GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"panther",
 		"gisat"
 	],
-	"homepage": "https://github.com/gisat-panther/ptr-state",
+	"homepage": "https://github.com/Gisat/ptr-state",
 	"prettier": "@gisatcz/prettier-config",
 	"husky": {
 		"hooks": {
@@ -23,7 +23,7 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/gisat-panther/ptr-state"
+		"url": "https://github.com/Gisat/ptr-state"
 	},
 	"peerDependencies": {
 		"react": "^16.13.1 || ^17.0.2 || ^18.1.0 ",


### PR DESCRIPTION
## Summary
- Fixed semantic-release failing due to repository URL mismatch

## Problem
The release workflow was failing with `EMISMATCHGITHUBURL` error because the repository URL in package.json (`gisat-panther/ptr-state`) did not match the actual GitHub repo URL (`Gisat/ptr-state`).

## Solution
Updated both `homepage` and `repository.url` fields in package.json to use the correct GitHub URL.

## Changes
- package.json: Updated `homepage` and `repository.url` from `gisat-panther/ptr-state` to `Gisat/ptr-state`