### PR TITLE
fix: update repository URL to match GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"panther",
 		"gisat"
 	],
-	"homepage": "https://github.com/gisat-panther/ptr-state",
+	"homepage": "https://github.com/Gisat/ptr-state",
 	"prettier": "@gisatcz/prettier-config",
 	"husky": {
 		"hooks": {
@@ -23,7 +23,7 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/gisat-panther/ptr-state"
+		"url": "https://github.com/Gisat/ptr-state"
 	},
 	"peerDependencies": {
 		"react": "^16.13.1 || ^17.0.2 || ^18.1.0 ",


### PR DESCRIPTION
## Problem
The release workflow failed with `EMISMATCHGITHUBURL` because `package.json` references the old organization `gisat-panther/ptr-state` instead of the current `Gisat/ptr-state`.

This was previously fixed but the dev→master merge (`#171`) reintroduced the old URL from the dev branch.

## Fix
Updated both `homepage` and `repository.url` in `package.json` from `gisat-panther` to `Gisat`.

## Changes
- `package.json:10` — homepage URL corrected
- `package.json:26` — repository URL corrected