### PR TITLE
fix: configure conventionalcommits preset for semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"babel-plugin-lodash": "^3.3.4",
 				"babel-plugin-transform-import-meta": "^2.3.3",
 				"chai": "^4.3.4",
+				"conventional-changelog-conventionalcommits": "^9.3.0",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.17.0",
 				"eslint-config-prettier": "^8.5.0",
@@ -4013,8 +4014,7 @@
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.5",
@@ -5020,7 +5020,6 @@
 			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^5.1.0"
@@ -5057,6 +5056,19 @@
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-changelog-conventionalcommits": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
+			"integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
+			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
 			},
@@ -5503,7 +5515,6 @@
 			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"is-obj": "^2.0.0"
 			},
@@ -7658,7 +7669,6 @@
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -18677,8 +18687,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"array-includes": {
 			"version": "3.1.5",
@@ -19411,7 +19420,6 @@
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
 			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^5.1.0"
@@ -19446,6 +19454,15 @@
 			"integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
 			"dev": true,
 			"peer": true,
+			"requires": {
+				"compare-func": "^2.0.0"
+			}
+		},
+		"conventional-changelog-conventionalcommits": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
+			"integrity": "sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0"
 			}
@@ -19750,7 +19767,6 @@
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
 			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
@@ -21298,8 +21314,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@rollup/plugin-babel": "^5.3.0",
 		"@rollup/plugin-commonjs": "^22.0.0",
 		"@semantic-release/git": "^10.0.1",
+		"conventional-changelog-conventionalcommits": "^9.3.0",
 		"babel-loader": "^8.2.3",
 		"babel-plugin-istanbul": "^6.1.1",
 		"babel-plugin-lodash": "^3.3.4",
@@ -93,8 +94,18 @@
 			}
 		],
 		"plugins": [
-			"@semantic-release/commit-analyzer",
-			"@semantic-release/release-notes-generator",
+			[
+				"@semantic-release/commit-analyzer",
+				{
+					"preset": "conventionalcommits"
+				}
+			],
+			[
+				"@semantic-release/release-notes-generator",
+				{
+					"preset": "conventionalcommits"
+				}
+			],
 			"@semantic-release/npm",
 			[
 				"@semantic-release/git",


### PR DESCRIPTION
## Problem

PR #173 added `feat!: promote to v3 production release` but semantic-release did not create a v3.0.0 release. The commit-analyzer logged:

> The commit should not trigger a release

## Root Cause

Semantic-release's default commit-analyzer uses the **`angular`** preset, which does not support the `!` breaking change syntax (`feat!:`). The `!` marker is part of the Conventional Commits spec, which requires the `conventionalcommits` preset.

The Angular preset only recognizes breaking changes via the `BREAKING CHANGE:` footer in the commit body — not the `!` suffix.

## Solution

1. Set `preset: "conventionalcommits"` on `@semantic-release/commit-analyzer`
2. Set `preset: "conventionalcommits"` on `@semantic-release/release-notes-generator` (for consistent formatting)
3. Add `conventional-changelog-conventionalcommits` to devDependencies (required by the preset)

## Expected Behavior

When this PR is merged, semantic-release will re-analyze all commits since `v2.7.0`:
- `Merge pull request #173...` → not a conventional commit → skipped
- `feat!: promote to v3 production release` → **now recognized as major** → v3.0.0
- `fix: configure conventionalcommits preset...` → patch (lower precedence than major)

Result: **v3.0.0** release is created.

## Changes

- `package.json` — added `conventional-changelog-conventionalcommits` dep, configured preset on commit-analyzer and release-notes-generator
- `package-lock.json` — updated via `npm install`